### PR TITLE
修复`README.md`里的图片链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,41 +19,41 @@ https://www.bilibili.com/video/av89568075
 用户名：hiolabs  
 密码：hiolabs
 
-<a target="_blank" href="https://www.aliyun.com/minisite/goods?userCode=zm04niet"><img width="1400" src="http://git.hiolabs.com/aliyun.jpg"/></a>
+<a target="_blank" href="https://www.aliyun.com/minisite/goods?userCode=zm04niet"><img width="1400" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/aliyun.jpg"/></a>
 阿里云主机：低至2折<a target="_blank" href="https://www.aliyun.com/minisite/goods?userCode=zm04niet">立即去看看</a>
 
 ### 项目截图
 + Dashboard
 
-<img width="900" src="http://git.hiolabs.com/github/dashboard.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/dashboard.jpg"/>
 
 + 订单
 
-<img width="900" src="http://git.hiolabs.com/github/order.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/order.jpg"/>
 
 + 电子面单生成
 
-<img width="900" src="http://git.hiolabs.com/github/express2.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/express2.jpg"/>
 
 + 商品管理
 
-<img width="900" src="http://git.hiolabs.com/github/goods.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/goods.jpg"/>
 
 + 购物车
 
-<img width="900" src="http://git.hiolabs.com/github/cart.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/cart.jpg"/>
 
 + 用户
 
-<img width="900" src="http://git.hiolabs.com/github/user.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/user.jpg"/>
 
 + 运费模板
 
-<img width="900" src="http://git.hiolabs.com/github/template.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/template.jpg"/>
 
 + 运费模板详情页
 
-<img width="900" src="http://git.hiolabs.com/github/template2.jpg"/>
+<img width="900" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/template2.jpg"/>
 
 ### 本地开发环境配置
 + 克隆项目到本地
@@ -67,16 +67,16 @@ npm install
 ```
 安装依赖后启动后会出现一个问题。
 
-<img width="600" src="http://git.hiolabs.com/github/error.jpg"/>
+<img width="600" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/error.jpg"/>
 
 这个问题是Element-ui自带的。解决方法：
 
 在node_modules 搜索:  div class="el-form-item__label-wrap" style={style}  
 然后在语句中加上单引号就可以了。
 
-<img width="600" src="http://git.hiolabs.com/github/before.jpg"/>
+<img width="600" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/before.jpg"/>
 
-<img width="600" src="http://git.hiolabs.com/github/after.jpg"/>
+<img width="600" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/after.jpg"/>
 
 + 启动
 ```
@@ -101,7 +101,7 @@ npm run build:web 或者 sudo npm run build:web
 
 ### 最近更新 
 - 新增生成分享图的功能
-<img width="1000" src="http://git.hiolabs.com/github/save-local.jpg"/>
+<img width="1000" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/save-local.jpg"/>
 
 - 项目地址  
 后台管理：https://github.com/iamdarcy/hioshop-admin  
@@ -109,5 +109,5 @@ npm run build:web 或者 sudo npm run build:web
 微信小程序：https://github.com/iamdarcy/hioshop-miniprogram  
 
 - 本项目会持续更新和维护，喜欢别忘了 Star，有问题可通过微信、QQ群联系我，谢谢您的关注。
-<img width="1200" src="http://git.hiolabs.com/github/contact.jpg"/>
+<img width="1200" src="https://raw.githubusercontent.com/iamdarcy/hiolabs/master/git-images/contact.jpg"/>
 


### PR DESCRIPTION
## Updates

- 由于`hiolabs.com`域名目前已失效，现将README.md里面的图片链接进行替换成 https://github.com/iamdarcy/hiolabs repo里面托管的图片

## Known issues

- 项目展示的截图 `http://git.hiolabs.com/miniapp.jpg` 目前没有在Git repo里面找到，可能需要重新上传