### PR TITLE
更新BootCDN地址

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0">
     <title>admin</title>
-    <link href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="https://cdn.bootcdn.net/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
     <link href="static/css/wap.css" rel="stylesheet">
 
     <% if (htmlWebpackPlugin.options.nodeModules) { %>


### PR DESCRIPTION
BootCDN 对外提供服务的域名已经于两年前（即 2020 年）变更为新域名 cdn.bootcdn.net，
老域名 cdn.bootcss.com 将于 2022 年 3 月 31 日下线。

注意新文件路径中添加了 ajax/libs 字样。
例如：https://cdn.bootcss.com/jquery/3.6.0/jquery.min.js
变更为：https://cdn.bootcdn.net/ajax/libs/jquery/3.6.0/jquery.min.js